### PR TITLE
Fix multimap npc and add Auto-expand feature

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -419,7 +419,7 @@ export default class Main extends React.Component {
     }
 
     render() {
-        if (!this.state.items) return <Home />;
+        // if (!this.state.items) return <Home />;
         const style = { minHeight: (window.innerHeight - 46), paddingTop:1 };
         return (
             <div>

--- a/src/components/conditions/ExpandingName.jsx
+++ b/src/components/conditions/ExpandingName.jsx
@@ -19,7 +19,7 @@ export default class ExpandingName extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            expanded: false,
+            expanded: window.location.href.endsWith(this.props.data.id.toLowerCase()),
         }
         this.toggleExpand = this.toggleExpand.bind(this);
     }

--- a/src/components/css/ExpandingName.css
+++ b/src/components/css/ExpandingName.css
@@ -1,0 +1,15 @@
+.expandedLink {
+    text-align: left;
+}
+
+.expandedText {
+    /* margin-left: 10;
+    white-space: 'nowrap';
+    overflow: 'hidden'; */
+    text-overflow: 'ellipsis';
+}
+
+.expandedTable {
+    padding-top: 10px;
+    margin-left: -10px;
+}

--- a/src/components/items/ExpandingName.jsx
+++ b/src/components/items/ExpandingName.jsx
@@ -19,7 +19,7 @@ export default class ExpandingName extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            expanded: false,
+            expanded: window.location.href.endsWith(this.props.data.id.toLowerCase()),
         }
         this.toggleExpand = this.toggleExpand.bind(this);
     }

--- a/src/components/monsters/ExpandingName.jsx
+++ b/src/components/monsters/ExpandingName.jsx
@@ -21,7 +21,7 @@ export default class ExpandingName extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            expanded: false,
+            expanded: window.location.href.endsWith(this.props.data.id.toLowerCase()),
         }
         this.toggleExpand = this.toggleExpand.bind(this);
     }

--- a/src/components/npc/ExpandingName.jsx
+++ b/src/components/npc/ExpandingName.jsx
@@ -23,7 +23,7 @@ export default class ExpandingName extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            expanded: false,
+            expanded: window.location.href.endsWith(this.props.data.id.toLowerCase()),
         }
         this.toggleExpand = this.toggleExpand.bind(this);
     }

--- a/src/components/npc/ExpandingName.jsx
+++ b/src/components/npc/ExpandingName.jsx
@@ -49,21 +49,21 @@ export default class ExpandingName extends React.Component {
                 <React.Fragment>
                     <div style={{ display:'flex'}}>
                         <div style={{ width: 19}} />
-                        <span class='expandedText'>{value}</span>
+                        <span className='expandedText'>{value}</span>
                     </div>
                 </React.Fragment>
             );
         }
         return (
             <React.Fragment>
-                <div class="expandedLink"
+                <div className="expandedLink"
                     style={{height: this.fixedHeight}}
                     onClick={this.toggleExpand}
                 >
                     <img src="../image/sort_desc.png" />
-                    <span class='expandedText'>{value}</span>
+                    <span className='expandedText'>{value}</span>
                 </div>
-                <div class="expandedTable">
+                <div className="expandedTable">
                     {(this.state.expanded) && <SellItemsTable data={links}/>}
                     {(this.state.expanded) && <QuestItemsTable data={questItemsLinks}/>}
                     {(this.state.expanded) && <QuestsTable data={quests}/>}

--- a/src/components/npc/ExpandingName.jsx
+++ b/src/components/npc/ExpandingName.jsx
@@ -4,24 +4,27 @@ import MapsList from '../MapsList';
 import SellItemsTable from './LinksTable';
 import QuestItemsTable from './QuestItemsTable';
 import QuestsTable from './QuestsTable';
+import '../css/ExpandingName.css';
 
-const styles = {
-    text: {
-        marginLeft: 10,
-        whiteSpace: 'nowrap',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis'
-    },
-    table: {
-        paddingTop: 10,
-        marginLeft: -10,
-    },
-}
+const fixedBaseHeight = 19.8;
+const fixedUnitHeight = 29.8;
+
+const unique = (item, pos, self) => self.indexOf(item) == pos;
 
 export default class ExpandingName extends React.Component {
 
     constructor(props) {
         super(props);
+        
+        // use groupLinks to extract how many lines in location cells
+        // bind to variable fixedheight
+        let maps = this.props.data.spawnGroupLinks;
+        if (maps.length > 0) {
+            maps = maps[0].maps.filter(unique);
+        }
+        this.fixedHeight = fixedBaseHeight + (maps.length - 1) * fixedUnitHeight;
+
+
         this.state = {
             expanded: window.location.href.endsWith(this.props.data.id.toLowerCase()),
         }
@@ -43,25 +46,30 @@ export default class ExpandingName extends React.Component {
 
         if (!links && !quests?.length && !questItemsLinks?.length) {
             return (
-              <React.Fragment>
-                    <div style={{ display:'flex'}} >
+                <React.Fragment>
+                    <div style={{ display:'flex'}}>
                         <div style={{ width: 19}} />
-                        <span style={styles.text}>{value}</span>
+                        <span class='expandedText'>{value}</span>
                     </div>
-              </React.Fragment> );
+                </React.Fragment>
+            );
         }
         return (
-              <React.Fragment>
-                    <div style={{ display:'flex'}} onClick={this.toggleExpand}>
-                            <img src="../image/sort_desc.png" />
-                            <span style={styles.text}>{value}</span>
-                    </div>
-                    <div style={styles.table}>
-                        {(this.state.expanded) && <SellItemsTable data={links}/>}
-                        {(this.state.expanded) && <QuestItemsTable data={questItemsLinks}/>}
-                        {(this.state.expanded) && <QuestsTable data={quests}/>}
-                    </div>
+            <React.Fragment>
+                <div class="expandedLink"
+                    style={{height: this.fixedHeight}}
+                    onClick={this.toggleExpand}
+                >
+                    <img src="../image/sort_desc.png" />
+                    <span class='expandedText'>{value}</span>
+                </div>
+                <div class="expandedTable">
+                    {(this.state.expanded) && <SellItemsTable data={links}/>}
+                    {(this.state.expanded) && <QuestItemsTable data={questItemsLinks}/>}
+                    {(this.state.expanded) && <QuestsTable data={quests}/>}
+                </div>
 
-              </React.Fragment> );
+            </React.Fragment>
+        );
     }
 }

--- a/src/components/npc/LocationCell.jsx
+++ b/src/components/npc/LocationCell.jsx
@@ -10,7 +10,7 @@ const getRowsData = function (data) {
         const maps = data?.flatMap((e) => e.maps)?.filter(unique);
         return maps?.map((row, index) => {
             const href = row.rootLink + row.name + "#" + data[0].key;
-            return <Link key={index} to={href} className="nps-location-cell">{row.name}</Link>;
+            return <Link key={index} to={href} className="npc-location-cell">{row.name}</Link>;
         })
     }
 

--- a/src/components/npc/NpcPage.jsx
+++ b/src/components/npc/NpcPage.jsx
@@ -14,10 +14,10 @@ export default class MonstersPage extends React.Component {
         return (
             <div>
                 <ul className="hr">
-                        {LiLink("/npc/", "merchant", this.props.location.pathname)}
-                        {LiLink("/npc/", "A-G", this.props.location.pathname)}
-                        {LiLink("/npc/", "H-R", this.props.location.pathname)}
-                        {LiLink("/npc/", "S-Z", this.props.location.pathname)}
+                    {LiLink("/npc/", "merchant", this.props.location.pathname)}
+                    {LiLink("/npc/", "A-G", this.props.location.pathname)}
+                    {LiLink("/npc/", "H-R", this.props.location.pathname)}
+                    {LiLink("/npc/", "S-Z", this.props.location.pathname)}
                 </ul>
                 <Switch>
                     <PropsRoute  path="/npc/a-g" component={NpcTable}

--- a/src/components/quests/ExpandingName.jsx
+++ b/src/components/quests/ExpandingName.jsx
@@ -20,7 +20,7 @@ export default class ExpandingName extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            expanded: false,
+            expanded: window.location.href.endsWith(this.props.data.id.toLowerCase()),
         }
         this.toggleExpand = this.toggleExpand.bind(this);
     }

--- a/src/index.css
+++ b/src/index.css
@@ -60,7 +60,7 @@ div.rgt-cell-header-inner {
     padding-right: 1px;
 }
 
-.nps-location-cell {
+.npc-location-cell {
     text-transform: capitalize;
     display: flex;
     margin: 10px;
@@ -153,7 +153,7 @@ a {
     color: white;
 }
 
-.nps-location-cell {
+.npc-location-cell {
     color: white;
 }
 


### PR DESCRIPTION
## Things I do
- Fix #6 
  This is a CSS bug, I solve it in the traditional CSS way (not flex).
  Use spawnGroupLinks to calculate a fixed height of the clickable expandedLink. Keep space for the locations of spawnGroupLinks. Not a beautiful solution actually.
  **So, I move some in-jsx style out and put them into `.css` file.**
- Auto-expand block when a tag is given from URL
  - Auto-expand happen **just one time for website initialization**, see
    http://localhost:3000/conditions#bless
    http://localhost:3000/items/body#packhide
    http://localhost:3000/monsters/animal#anklebiter4
    http://localhost:3000/npc/merchant#birgil
    http://localhost:3000/quests#bucus
    (testing for each ExpandingName.jsx I modified)

@reizy Is auto-expand necessary for your opinion? If so, should we put them into other scenarios (these won't get auto-expand now):
1. click the link on the same page
2. ...(I forget one kind of scenario)