### PR TITLE
Resource loading optimization and Pre-rendering in JSON loading stage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -86,7 +86,12 @@ function App() {
 
   return (
     <div className="App">
-        { data.resources && <Main resources = { data.resources } maps = { data.maps } globalMap = { data.globalMap }/> }
+        {/* { data.resources && <Main resources = { data.resources } maps = { data.maps } globalMap = { data.globalMap }/> } */}
+        <Main
+          resources = { data.resources }
+          maps = { data.maps }
+          globalMap = { data.globalMap }
+        />
     </div>
   );
 }

--- a/src/components/Main.css
+++ b/src/components/Main.css
@@ -1,11 +1,5 @@
-body {
-    justify-content: center;
-    align-items: center;
-    background: #000;
-    display: flex;
-    height: 100vh;
-    padding: 0;
-    margin: 0;
+.content {
+    padding: 0px 40px;
 }
 
 .progress {

--- a/src/components/Main.css
+++ b/src/components/Main.css
@@ -1,0 +1,29 @@
+body {
+    justify-content: center;
+    align-items: center;
+    background: #000;
+    display: flex;
+    height: 100vh;
+    padding: 0;
+    margin: 0;
+}
+
+.progress {
+    background: rgba(255,255,255,0.1);
+    justify-content: flex-start;
+    border-radius: 100px;
+    align-items: center;
+    position: relative;
+    padding: 0 5px;
+    display: flex;
+    height: 20px;
+    width: '100%';
+}
+
+.progress-value {
+    box-shadow: 0 10px 40px -10px #fff;
+    border-radius: 100px;
+    background: #fff;
+    height: 30px;
+    width: 0;
+}

--- a/src/components/Main.css
+++ b/src/components/Main.css
@@ -12,6 +12,7 @@
     width: 50%;
 }
 
+/* Progress bar is from https://codepen.io/traf/pen/oKbaqQ, Author: Traf */
 .progress {
     background: rgba(255,255,255,0.1);
     justify-content: flex-start;

--- a/src/components/Main.css
+++ b/src/components/Main.css
@@ -2,6 +2,16 @@
     padding: 0px 40px;
 }
 
+.loading-base {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 900px;
+}
+.loading-container {
+    width: 50%;
+}
+
 .progress {
     background: rgba(255,255,255,0.1);
     justify-content: flex-start;
@@ -20,4 +30,5 @@
     background: #fff;
     height: 30px;
     width: 0;
+    transition: .1s;
 }

--- a/src/components/Main.css
+++ b/src/components/Main.css
@@ -6,7 +6,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 900px;
+    min-height: 200px;
 }
 .loading-container {
     width: 50%;

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -13,7 +13,7 @@ import QuestsPage from './quests/QuestsPage';
 import MapPage from './maps/MapPage';
 import calculateCost from './CostCalculator';
 import expCalculator from './ExpCalculator';
-import './Main.css'
+import './Main.css';
 
 // const Loading = () => ;
 function Loading (props) {
@@ -473,7 +473,7 @@ export default class Main extends React.Component {
         };
         return (
             <div>
-                <div style={style}>
+                <div className="content" style={style}>
                     <Switch>
                         <Menu />
                     </Switch>

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -13,12 +13,41 @@ import QuestsPage from './quests/QuestsPage';
 import MapPage from './maps/MapPage';
 import calculateCost from './CostCalculator';
 import expCalculator from './ExpCalculator';
+import './Main.css'
+
+// const Loading = () => ;
+function Loading (props) {
+    let mp = props.maxProgress;
+    let p = props.progress;
+    let percentage = (mp - p) / mp * 100;
+    return (
+        <div>
+            { props.progress === undefined ? (
+                <h3>Loading TMS...</h3>
+            ) : (
+                <div>
+                    <div className="progress">
+                        <div
+                            className="progress-value"
+                            style={{width: `${percentage}%`}}
+                        />
+                    </div>
+                    <h3>
+                        Loading JSON...
+                        {mp - p} / {mp}
+                    </h3>
+                </div>
+            )}
+        </div>
+    );
+}
 
 export default class Main extends React.Component {
     constructor(props) {
         super(props);
-        this.state={
+        this.state = {
             expandedSubMenu: false,
+            loadJson: true,
         };
         this.temp={};
         this.toggleExpandSubMenu = this.toggleExpandSubMenu.bind(this);
@@ -28,24 +57,41 @@ export default class Main extends React.Component {
         this.setState({ expandedSubMenu: !this.state.expandedSubMenu, });
     }
 
-    getJsonResources=(resources)=>{
-      var downcounter = {progress:0};
-      this.getJsonResource(resources.loadresource_itemcategories, "itemcategories", downcounter);
-      this.getJsonResource(resources.loadresource_items, "items", downcounter);
-      this.getJsonResource(resources.loadresource_actorconditions, "actorconditions", downcounter);
-      this.getJsonResource(resources.loadresource_monsters, "monsters", downcounter);
-      this.getJsonResource(resources.loadresource_droplists, "droplists", downcounter);
-      this.getJsonResource(resources.loadresource_conversationlists, "conversations", downcounter);
-      this.getJsonResource(resources.loadresource_quests, "quests", downcounter);
+    getJsonResources = async (resources) => {
+        var downcounter = {progress: 0};
+        
+        const jsonResourcList = [
+            [resources.loadresource_itemcategories, "itemcategories"],
+            [resources.loadresource_items, "items"],
+            [resources.loadresource_actorconditions, "actorconditions"],
+            [resources.loadresource_monsters, "monsters"],
+            [resources.loadresource_droplists, "droplists"],
+            [resources.loadresource_conversationlists, "conversations"],
+            [resources.loadresource_quests, "quests"],
+        ];
 
+        // init maxProgress
+        const p = jsonResourcList.map(r => r[0].length).reduce((a, b) => a + b, 0);
+        this.setState({
+            progress: p,
+            maxProgress: p,
+        });
+
+        // parallelly send out jsonResourcList requests
+        await Promise.all(jsonResourcList.map(([loadResource, resourceName]) =>
+            this.getJsonResource(loadResource, resourceName, downcounter)
+        ));
+        console.log('well done');
     }
 
-    getJsonResource=(resource, name, downcounter)=>{
-      const that = this;
-      downcounter.progress+=resource.length;
-      resource.forEach((path)=>{
-          that.getJsonData(path.replace('@','/'), name, that, downcounter);
-      });
+    getJsonResource = async (resource, name, downcounter) => {
+        const that = this;
+        downcounter.progress += resource.length;
+        await Promise.all(resource.map(
+            path => that.getJsonData(path.replace('@','/'), name, that, downcounter)
+        ));
+
+        this.setState({progress: this.state.progress - resource.length});
     }
     countConditions = (effect, item, type) => {
         var count =  effect?.addedConditions?.length||0;
@@ -391,42 +437,51 @@ export default class Main extends React.Component {
         debug(this.temp);
     }
     
-    getJsonData=(fileName, name, that, downcounter)=>{
-        fetch(fileName+".json"
-        ,{
-            headers : { 
-            'Content-Type': 'application/json',
-            'Accept': 'application/json'
+    getJsonData = (fileName, name, that, downcounter) =>
+        fetch(fileName+".json", {
+            headers: { 
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
             }
         })
-        .then(function(response){
-            return response.json();
-        })
+        .then(response => response.json())
         .then(json => {
-          that.temp[name] = that.temp[name]||[];
+          that.temp[name] = that.temp[name] || [];
           that.temp[name] = that.temp[name].concat(json);
           downcounter.progress--;
           if (downcounter.progress == 0){
               that.linkTemp()
               that.setState(that.temp);
           }
-        });
-    }
+        })
 
     componentDidMount() {
        debug(this.props);
-       this.getJsonResources(this.props.resources);
+    }
+
+    componentDidUpdate() {
+        if (!this.state.items && this.state.loadJson) {
+            this.setState({loadJson: false});
+            this.getJsonResources(this.props.resources);
+        }
     }
 
     render() {
-        if (!this.state.items) return <Home />;
-        const style = { minHeight: (window.innerHeight - 46), paddingTop:1 };
+        const style = {
+            minHeight: (window.innerHeight - 46),
+            paddingTop: 1,
+        };
         return (
             <div>
                 <div style={style}>
                     <Switch>
                         <Menu />
                     </Switch>
+                    {/* Loading part */}
+                    { !this.state.items && <Loading
+                        progress={this.state.progress}
+                        maxProgress={this.state.maxProgress}
+                    />}
                     <Switch>
                         <Route exact path='/' component={Home}/>
                         <PropsRoute path='/items' component={ItemsPage} data = { this.state.items }/>

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -21,23 +21,25 @@ function Loading (props) {
     let p = props.progress;
     let percentage = (mp - p) / mp * 100;
     return (
-        <div>
-            { props.progress === undefined ? (
-                <h3>Loading TMS...</h3>
-            ) : (
-                <div>
-                    <div className="progress">
-                        <div
-                            className="progress-value"
-                            style={{width: `${percentage}%`}}
-                        />
+        <div className='loading-base'>
+            <div className='loading-container'>
+                { props.progress === undefined ? (
+                    <h3>Loading TMS...</h3>
+                ) : (
+                    <div>
+                        <div className="progress">
+                            <div
+                                className="progress-value"
+                                style={{width: `${percentage}%`}}
+                            />
+                        </div>
+                        <h3>
+                            Loading JSON...
+                            {mp - p} / {mp}
+                        </h3>
                     </div>
-                    <h3>
-                        Loading JSON...
-                        {mp - p} / {mp}
-                    </h3>
-                </div>
-            )}
+                )}
+            </div>
         </div>
     );
 }
@@ -474,14 +476,17 @@ export default class Main extends React.Component {
         return (
             <div>
                 <div className="content" style={style}>
-                    <Switch>
-                        <Menu />
-                    </Switch>
                     {/* Loading part */}
-                    { !this.state.items && <Loading
-                        progress={this.state.progress}
-                        maxProgress={this.state.maxProgress}
-                    />}
+                    {
+                        !this.state.items ?
+                        <Loading
+                            progress={this.state.progress}
+                            maxProgress={this.state.maxProgress}
+                        /> : (
+                        <Switch>
+                            <Menu />
+                        </Switch>
+                    )}
                     <Switch>
                         <Route exact path='/' component={Home}/>
                         <PropsRoute path='/items' component={ItemsPage} data = { this.state.items }/>

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -83,7 +83,6 @@ export default class Main extends React.Component {
         await Promise.all(jsonResourcList.map(([loadResource, resourceName]) =>
             this.getJsonResource(loadResource, resourceName, downcounter)
         ));
-        console.log('well done');
     }
 
     getJsonResource = async (resource, name, downcounter) => {
@@ -478,26 +477,30 @@ export default class Main extends React.Component {
                 <div className="content" style={style}>
                     {/* Loading part */}
                     {
-                        !this.state.items ?
+                        !this.state.items ? (
                         <Loading
                             progress={this.state.progress}
                             maxProgress={this.state.maxProgress}
-                        /> : (
-                        <Switch>
-                            <Menu />
-                        </Switch>
+                        />
+                    ) : (
+                        <div>
+                            <Switch>
+                                <Menu />
+                            </Switch>
+                            <Switch>
+                                <Route exact path='/' component={Home}/>
+                                <PropsRoute path='/items' component={ItemsPage} data = { this.state.items }/>
+                                <PropsRoute path='/conditions' component={ConditionsPage} data = { this.state.actorconditions }/>
+                                <PropsRoute path='/monsters' component={MonstersPage} data = { this.state.monsters }/>
+                                <PropsRoute path='/categories' component={ItemCategoriesTable} data = { this.state.itemcategories }/> 
+                                <PropsRoute path='/npc' component={NpcPage} data = { this.state.monsters }/> 
+                                <PropsRoute path='/quests' component={QuestsPage} data = { this.state.quests }/> 
+                                <PropsRoute path='/map' component={MapPage} data = { this.props.maps } globalMap = { this.props.globalMap }
+                                    expanded={this.state.expandedSubMenu} toggleExpand={this.toggleExpandSubMenu}/> 
+                            </Switch>
+                        </div>
                     )}
-                    <Switch>
-                        <Route exact path='/' component={Home}/>
-                        <PropsRoute path='/items' component={ItemsPage} data = { this.state.items }/>
-                        <PropsRoute path='/conditions' component={ConditionsPage} data = { this.state.actorconditions }/>
-                        <PropsRoute path='/monsters' component={MonstersPage} data = { this.state.monsters }/>
-                        <PropsRoute path='/categories' component={ItemCategoriesTable} data = { this.state.itemcategories }/> 
-                        <PropsRoute path='/npc' component={NpcPage} data = { this.state.monsters }/> 
-                        <PropsRoute path='/quests' component={QuestsPage} data = { this.state.quests }/> 
-                        <PropsRoute path='/map' component={MapPage} data = { this.props.maps } globalMap = { this.props.globalMap }
-                            expanded={this.state.expandedSubMenu} toggleExpand={this.toggleExpandSubMenu}/> 
-                    </Switch>
+                    
                 </div>
                 <div className="signature">
                     <div style={{float:'left'}}>

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -11,7 +11,9 @@ export default class Main extends React.Component {
         return (
             <menu>
                 <ul className="hr">
-                     <li className={(window.location.pathname=="/")?"selected":""}><Link to="">Home</Link></li>
+                    <li className={window.location.pathname === "/" ? "selected" : ""}>
+                        <Link to="">Home</Link>
+                    </li>
                     {LiLink("items", "/body")}
                     {LiLink("monsters", "/animal")}
                     {LiLink("NPC", "/merchant")}

--- a/src/components/conditions/ConditionsPage.jsx
+++ b/src/components/conditions/ConditionsPage.jsx
@@ -7,19 +7,14 @@ export default class ItemsPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "Loading...";
+        if (!this.props.data) return "";
         return ( 
-                 <div>
-                     Positive
-                     {
-                         <ConditionsTable data = { this.props.data.filter((e)=>e.isPositive)} />
-                     }
-                     <br/>
-                     Negative
-                     {
-                         <ConditionsTable data = { this.props.data.filter((e)=>!e.isPositive)}  />
-                     }
-                 </div> 
-               );
+            <div>
+                <h2>Positive</h2>
+                <ConditionsTable data = { this.props.data.filter((e)=>e.isPositive)} />
+                <h2>Negative</h2>
+                <ConditionsTable data = { this.props.data.filter((e)=>!e.isPositive)} />
+            </div> 
+        );
     }
 }

--- a/src/components/conditions/ConditionsPage.jsx
+++ b/src/components/conditions/ConditionsPage.jsx
@@ -7,7 +7,6 @@ export default class ItemsPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "";
         return ( 
             <div>
                 <h2>Positive</h2>

--- a/src/components/items/ItemsPage.jsx
+++ b/src/components/items/ItemsPage.jsx
@@ -12,7 +12,7 @@ export default class ItemsPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "Loading...";
+        if (!this.props.data) return "";
         return (
             <div>
                 <ul className="hr">

--- a/src/components/items/ItemsPage.jsx
+++ b/src/components/items/ItemsPage.jsx
@@ -12,7 +12,6 @@ export default class ItemsPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "";
         return (
             <div>
                 <ul className="hr">

--- a/src/components/maps/MapPage.jsx
+++ b/src/components/maps/MapPage.jsx
@@ -21,7 +21,7 @@ export default class Page extends React.Component {
     render() {
         const { data, globalMap, location } = this.props;
         var map = location.pathname.substring("/map/".length);
-        if (!data) return "Loading...";
+        if (!data) return "";
 
         return (
             <div>

--- a/src/components/monsters/MonstersPage.jsx
+++ b/src/components/monsters/MonstersPage.jsx
@@ -10,7 +10,6 @@ export default class MonstersPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "";
         return (
             <div>
                 <ul className="hr">

--- a/src/components/monsters/MonstersPage.jsx
+++ b/src/components/monsters/MonstersPage.jsx
@@ -10,7 +10,7 @@ export default class MonstersPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "Loading...";
+        if (!this.props.data) return "";
         return (
             <div>
                 <ul className="hr">

--- a/src/components/npc/NpcPage.jsx
+++ b/src/components/npc/NpcPage.jsx
@@ -10,7 +10,6 @@ export default class MonstersPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "";
         return (
             <div>
                 <ul className="hr">

--- a/src/components/npc/NpcPage.jsx
+++ b/src/components/npc/NpcPage.jsx
@@ -10,7 +10,7 @@ export default class MonstersPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "Loading...";
+        if (!this.props.data) return "";
         return (
             <div>
                 <ul className="hr">

--- a/src/components/quests/QuestsPage.jsx
+++ b/src/components/quests/QuestsPage.jsx
@@ -8,7 +8,6 @@ export default class ItemsPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "";
         return (
             <div>
                
@@ -18,7 +17,7 @@ export default class ItemsPage extends React.Component {
                     />
 
             </div> 
-               );
+        );
     }
 }
 

--- a/src/components/quests/QuestsPage.jsx
+++ b/src/components/quests/QuestsPage.jsx
@@ -8,7 +8,7 @@ export default class ItemsPage extends React.Component {
     }
 
     render() {
-        if (!this.props.data) return "Loading...";
+        if (!this.props.data) return "";
         return (
             <div>
                


### PR DESCRIPTION
Like #11 said, I did some pre-rendering.

## Parallel Resource Requesting

I parallelly send out the **resource requests for the JSON files** by `async`, `await` and `Promise.all`.
The original total loading time of website is `(15.96 + 17.24 + 15.96 + 17.9 + 17.42) / 5 =` **16.896 secs**.
After applying this PR, the time is `(10.77 + 11.81 + 13.03 + 13.38 + 10.85) / 5 = ` **11.968 secs**.
Speed up about 30%. We should consider adding formal testing scripts in the future.

I just did it for the JSON because the loading of TMX is outside of `Main.jsx`.
But TMX is the biggest performance bottleneck. I will try it.

## Pre-rendering & Website Initialization
I split the loading into serval stages.
No data -> Load TMX -> Load JSON -> Finish

### 1. Loading TMX
Show Loading status only. (footer shows up also)

![圖片](https://user-images.githubusercontent.com/22179367/148219210-9c527e58-ee6f-4b83-9ccd-e40a6997a765.png)

### 2. Load TMX finished -> Loading JSON
Show the JSON loading status bar based on the downcounter.

![圖片](https://user-images.githubusercontent.com/22179367/148219444-a1d0fa50-7c68-4667-b3b2-cf9e6c3018e2.png)

### 3. Finish
Show the menu and the content of this sub-page. 

![圖片](https://user-images.githubusercontent.com/22179367/148219617-abac8b75-aeac-4c75-896f-3dc1b26cc00c.png)

## Methods I added(used):
  - `async` and `await` to let the `getJsonResource` and `getJsonResources` can deal with asynchronous functions
  -  `getJsonData` directly return fetch Promise object, use `Promise.all` to parallelly send them out.