### PR TITLE
Speedup generateMapImages.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,24 @@
+.PHONY: link, gen, gen_test, run, build
 AT_FOLDER = "../andors-trail/AndorsTrail/"
 
-build:
-	export NODE_OPTIONS=--openssl-legacy-provider
-	npm run build
-	cp build/index.html build/404.html
-gen:
-	mkdir public/backgrounds || true
-	node bin/generateMapImages.js
-	node bin/getVersions.js
-gen_test:
-	mkdir public/backgrounds || true
-	node bin/generateMapImages.js graveyard1
+
 link:
 	rm public/[rxdv][arm]* || true
 	ln -s "../${AT_FOLDER}res/values" "public/values"
 	ln -s "../${AT_FOLDER}res/xml" "public/xml"
 	ln -s "../${AT_FOLDER}res/drawable" "public/drawable"
 	ln -s "../${AT_FOLDER}res/raw" "public/raw"
+gen:
+	mkdir public/backgrounds || true
+	node bin/generateMapImages.js
+	node bin/getVersion.js
+gen_test:
+	mkdir public/backgrounds || true
+	node bin/generateMapImages.js graveyard1
 run:
 	export NODE_OPTIONS=--openssl-legacy-provider
 	npm start
+build:
+	export NODE_OPTIONS=--openssl-legacy-provider
+	npm run build
+	cp build/index.html build/404.html

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 AT_FOLDER = "../andors-trail/AndorsTrail/"
 
+build:
+	export NODE_OPTIONS=--openssl-legacy-provider
+	npm run build
+	cp build/index.html build/404.html
 gen:
 	mkdir public/backgrounds || true
 	node bin/generateMapImages.js
-gen_grave:
+	node bin/getVersions.js
+gen_test:
 	mkdir public/backgrounds || true
 	node bin/generateMapImages.js graveyard1
 link:
@@ -13,4 +18,5 @@ link:
 	ln -s "../${AT_FOLDER}res/drawable" "public/drawable"
 	ln -s "../${AT_FOLDER}res/raw" "public/raw"
 run:
+	export NODE_OPTIONS=--openssl-legacy-provider
 	npm start

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 1. You need game sources (values, xml, drawable, raw) at "public" directry. I use "link.bat" to make Symbolic Link.
 2. You need have NPM installed. You can get it at https://nodejs.org/en/download/. 
 3. Run 'npm install'
-4. Run 'npm run gen' to render TMS to JPG for global map pages. Yes, it really takes a long time. (You can run 'npm run gen graveyard1' to render only one map 'graveyard1')
+4. Run 'npm run gen' to render TMX to JPG for global map pages. It takes 25.5s in MBP. (You can run 'npm run gen graveyard1' to render only one map 'graveyard1')
 5. Run 'npm start' for starting local development server.
 6. Run 'npm build' to generate production build.
 7. To make route from any page to index.html I use "build.bat"
@@ -19,9 +19,9 @@ If your system is UNIX, you can ues makefile instead of ".bat". Tested on my Mac
 1. `make link`: Make symbolic link to game resources (values, xml, drawable, raw) at "public" directry.
 2. You need have NPM installed. You can get it at https://nodejs.org/en/download/.
 3. `npm install`: Install required node.js package from package.json
-4. `make gen`: Render TMS to JPG for global map pages. Yes, it really takes a long time. (You can run `make gen_grave` to render only one map 'graveyard1' for test). Execute 1602.92s in my MBP.
+4. `make gen`: Render TMX to JPG for global map pages. It takes 25.5s in MBP. (You can run `make gen_test` to render only one map 'graveyard1' for test).
 5. `make run`: Starting local development server.
-6. `npm run build`: Generate production build.
+6. `make build`: Generate production build.
 <!-- 7. To make route from any pages to index.html I use "build.bat" -->
 
 ## Learn More

--- a/bin/generateMapImages.js
+++ b/bin/generateMapImages.js
@@ -10,6 +10,9 @@ const ZOOM_OUT = 12;
 var counter = 0;
 var counterSize = 0;
 
+// cache of image, key is string from tileset.name, value is Image from node-canvas
+var imageCache = {};
+
 function saveCanvas(canvas, fileName) {
     counter++;
     console.log(`[${counter}/${counterSize}] ${fileName}`);
@@ -20,19 +23,22 @@ function saveCanvas(canvas, fileName) {
 function drawCell(context, x, y, cell, layerList, thenDo) {
     layerList.forEach((e) => drawCellLayer(context, x, y, cell[e.name], thenDo));
 }
-function drawCellLayer(context, x, y, cell, thenDo) {
+async function drawCellLayer(context, x, y, cell, thenDo) {
     if (!cell) return thenDo();
 
     const tileset = cell.tileset;
 
+    if (!(tileset.name in imageCache)) {
+        const image = await loadImage('./public/drawable/' + tileset.name + '.png');
+        imageCache[tileset.name] = image;
+    }
 
-    loadImage('./public/drawable/' + tileset.name + '.png').then(image => {
-      const dx = cell.localid % tileset.columns;
-      const dy = Math.floor(cell.localid / tileset.columns);
+    const dx = cell.localid % tileset.columns;
+    const dy = Math.floor(cell.localid / tileset.columns);
+    const image = imageCache[tileset.name];
 
-      context.drawImage(image, dx * ZOOM, dy * ZOOM, ZOOM, ZOOM, x * ZOOM_OUT, y * ZOOM_OUT, ZOOM_OUT, ZOOM_OUT)
-      thenDo();
-    })
+    context.drawImage(image, dx * ZOOM, dy * ZOOM, ZOOM, ZOOM, x * ZOOM_OUT, y * ZOOM_OUT, ZOOM_OUT, ZOOM_OUT);
+    thenDo();
 }
 function drawCanvas(fileName, map) {
     const width = map.width * ZOOM_OUT;

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -24,7 +24,7 @@ function Loading (props) {
         <div className='loading-base'>
             <div className='loading-container'>
                 { props.progress === undefined ? (
-                    <h3>Loading TMS...</h3>
+                    <h3>Loading TMX...</h3>
                 ) : (
                     <div>
                         <div className="progress">


### PR DESCRIPTION
Hi @reizy, I've come back with some improvements to this repo. 

When I investigated the game data processing script, there was a bottleneck in `/bin/generateMapImages.js`.
It read the original image data several times by `readImage()` from node-canvas.

We can use a cache of mapping from the name of the tileset to the corresponding `Image` object.
Reusing the image cache when we need the same resource to prevent redundant OS reading time.
This patch cost 25.5s instead of 1600s—speed up about 62x.

I update the README.md and Makefile. Also, fix a typo of "tmx" instead of "tms". (It must be a typo, right?)